### PR TITLE
make image names configurable via template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,26 @@
-# Gitlab Registry Cleanup Hook
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.5.0] - 2018-11-06
+
+### Added
+- Make image names configurable via template [#8], [#2]
+
+[0.5.0]: https://github.com/glensc/gitlab-registry-cleanup-hook/compare/0.4.0...0.5.0
+[#8]: https://github.com/glensc/gitlab-registry-cleanup-hook/pull/8
+[#2]: https://github.com/glensc/gitlab-registry-cleanup-hook/issues/1
 
 ## [0.4.0] - 2018-11-04
 
-NOTE: `GITLAB_PASSWORD` env is renamed to `GITLAB_TOKEN`
-
+### Added
 - Added docker swarm example with secrets [#6]
+
+### Changed
+- `GITLAB_PASSWORD` env is renamed to `GITLAB_TOKEN`
 - Skip projects without Registry enabled [#7], [#3]
 
 [0.4.0]: https://github.com/glensc/gitlab-registry-cleanup-hook/compare/0.3.0...0.4.0
@@ -14,6 +30,7 @@ NOTE: `GITLAB_PASSWORD` env is renamed to `GITLAB_TOKEN`
 
 ## [0.3.0] - 2018-10-25
 
+### Changed
 - Use api to delete images, no longer requiring direct docker registry filesystem access [#1], [#5]
 
 [0.3.0]: https://github.com/glensc/gitlab-registry-cleanup-hook/compare/0.2.1...0.3.0
@@ -22,6 +39,7 @@ NOTE: `GITLAB_PASSWORD` env is renamed to `GITLAB_TOKEN`
 
 ## [0.2.1] - 2018-10-15
 
+### Fixed
 - Workaround for [gitlab-ce#52672] sending wrong events to the hook
 
 [0.2.1]: https://github.com/glensc/gitlab-registry-cleanup-hook/compare/0.2.0...0.2.1
@@ -29,6 +47,7 @@ NOTE: `GITLAB_PASSWORD` env is renamed to `GITLAB_TOKEN`
 
 ## [0.2.0] - 2018-10-13
 
+### Added
 - Add `Dockerfile`, `docker-compose.yml`.
 - Load Hook token from `$HOOK_TOKEN` environment variable.
 - Support setup as System Hook
@@ -37,6 +56,7 @@ NOTE: `GITLAB_PASSWORD` env is renamed to `GITLAB_TOKEN`
 
 ## [0.1.0] - 2018-10-13
 
+### Added
 - Add Gitlab Registry Cleanup Hook (Python) snippet from https://gitlab.com/snippets/1091155/
 
 [0.1.0]: https://github.com/glensc/gitlab-registry-cleanup-hook/commits/0.1.0

--- a/README.md
+++ b/README.md
@@ -14,6 +14,34 @@ Create system hook from `/admin/hooks`
 - Secret Token: same as `$HOOK_TOKEN` from the `.env`
 - Trigger: Merge request events
 
+## Customize images to delete
+
+By default `IMAGE_NAME_TEMPLATE=%(project_path)s/branches:%(branch)s` is used to find images to delete.
+
+It's a comma separated list of images to delete.
+
+You can override this per project,
+by setting [project custom attribute].
+
+[project custom attribute]: https://docs.gitlab.com/ce/api/custom_attributes.html
+
+```bash
+# Project custom attribute name to set per project override for IMAGE_NAME_TEMPLATE
+# https://docs.gitlab.com/ce/api/custom_attributes.html
+IMAGE_NAME_PROJECT_ATTRIBUTE=gitlab_registry_image_template
+```
+
+This will configure to cleanup `branches:BRANCH_NAME-node-8` and `branch:BRANCH_NAME-node-10` images when MR is merged:
+```bash
+./set-project-attribute.sh gitlab-org/gitlab-ce '%(project_path)s/branches:%(branch)s-node-8,%(project_path)s/branches:%(branch)s-node-10'
+{"key":"custom_attribute","value":"%(project_path)s/branches:%(branch)s-node-8,%(project_path)s/branches:%(branch)s-node-10"}
+```
+
+Invoking helper script without value, will delete the attribute:
+```bash
+./set-project-attribute.sh gitlab-org/gitlab-ce
+```
+
 ## Credits
 
 - [@morph027] for original [Python Gist]

--- a/env.example
+++ b/env.example
@@ -11,7 +11,7 @@ GITLAB_JWT_URL=https://gitlab.example.net/jwt/auth
 GITLAB_REGISTRY=https://gitlab.example.net:4567/
 
 # template to use to construct image to cleanup
-IMAGE_NAME_TEMPLATE=%(project_name)s/builds:%(slug)s
+IMAGE_NAME_TEMPLATE=%(project_path)s/branches:%(branch)s
 
 # Project custom attribute name to set per project override for IMAGE_NAME_TEMPLATE
 # https://docs.gitlab.com/ce/api/custom_attributes.html

--- a/env.example
+++ b/env.example
@@ -10,6 +10,13 @@ GITLAB_API_URL=https://gitlab.example.net
 GITLAB_JWT_URL=https://gitlab.example.net/jwt/auth
 GITLAB_REGISTRY=https://gitlab.example.net:4567/
 
+# template to use to construct image to cleanup
+IMAGE_NAME_TEMPLATE=%(project_name)s/builds:%(slug)s
+
+# Project custom attribute name to set per project override for IMAGE_NAME_TEMPLATE
+# https://docs.gitlab.com/ce/api/custom_attributes.html
+IMAGE_NAME_PROJECT_ATTRIBUTE=gitlab_registry_image_template
+
 # Token that should be used when GitLab posts to this endpoint.
 # Basic security, add this token to the project's webhook.
 # get one:

--- a/gitlab-registry-cleanup-hook.py
+++ b/gitlab-registry-cleanup-hook.py
@@ -111,9 +111,12 @@ def get_image_delete_list(project, data):
     project_attribute = config.get('IMAGE_NAME_PROJECT_ATTRIBUTE')
     if project_attribute:
         # https://python-gitlab.readthedocs.io/en/stable/gl_objects/projects.html#project-custom-attributes
-        attribute_value = project.customattributes.get(project_attribute)
-        if attribute_value != None:
-            image_template = attribute_value
+        try:
+            attribute_value = project.customattributes.get(project_attribute)
+            if attribute_value != None:
+                image_template = attribute_value
+        except gitlab.exceptions.GitlabGetError:
+            pass
 
     attributes = {
         'branch': data['object_attributes']['source_branch'],

--- a/gitlab-registry-cleanup-hook.py
+++ b/gitlab-registry-cleanup-hook.py
@@ -109,12 +109,11 @@ def validate():
 def get_image_delete_list(project, data):
     image_template = config.get('IMAGE_NAME_TEMPLATE', '%(project_path)s/branches:%(branch)s')
     project_attribute = config.get('IMAGE_NAME_PROJECT_ATTRIBUTE')
-
-    # https://python-gitlab.readthedocs.io/en/stable/gl_objects/projects.html#project-custom-attributes
-    attribute_value = project.customattributes.get(project_attribute)
-
-    if attribute_value != None:
-        image_template = attribute_value
+    if project_attribute:
+        # https://python-gitlab.readthedocs.io/en/stable/gl_objects/projects.html#project-custom-attributes
+        attribute_value = project.customattributes.get(project_attribute)
+        if attribute_value != None:
+            image_template = attribute_value
 
     attributes = {
         'branch': data['object_attributes']['source_branch'],

--- a/gitlab-registry-cleanup-hook.py
+++ b/gitlab-registry-cleanup-hook.py
@@ -112,9 +112,10 @@ def get_image_delete_list(project, data):
     if project_attribute:
         # https://python-gitlab.readthedocs.io/en/stable/gl_objects/projects.html#project-custom-attributes
         try:
-            attribute_value = project.customattributes.get(project_attribute)
-            if attribute_value != None:
-                image_template = attribute_value
+            # https://python-gitlab.readthedocs.io/en/stable/api/gitlab.v4.html#gitlab.v4.objects.ProjectCustomAttribute
+            attribute = project.customattributes.get(project_attribute)
+            # https://python-gitlab.readthedocs.io/en/stable/api/gitlab.v4.html#gitlab.v4.objects.ProjectCustomAttribute
+            image_template = attribute.value
         except gitlab.exceptions.GitlabGetError:
             pass
 
@@ -124,8 +125,8 @@ def get_image_delete_list(project, data):
     }
 
     for template in image_template.split(','):
-        image = template % attributes
-        yield image
+        image, tag = (template % attributes).split(':')
+        yield image, tag
 
 
 def cleanup(data):

--- a/gitlab-registry-cleanup-hook.py
+++ b/gitlab-registry-cleanup-hook.py
@@ -103,7 +103,7 @@ def validate():
         logger.info("Registry not enabled; skip")
         return NoContentResponse
 
-    return cleanup(data)
+    return cleanup(project, data)
 
 
 def get_image_delete_list(project, data):
@@ -127,6 +127,7 @@ def get_image_delete_list(project, data):
         image, tag = (template % attributes).split(':')
         yield image, tag
 
+
 def delete_image(image, tag):
     logger.info("Trying to delete %s:%s" % (image, tag))
     digest = client.get_digest(image, tag)
@@ -142,10 +143,8 @@ def delete_image(image, tag):
     logger.info("Image not deleted")
     return {'message' : 'Image not deleted', 'image': image, 'tag': tag, 'code': 202}
 
-def cleanup(data):
-    project_id = data['project']['id']
-    project = gl.projects.get(project_id)
 
+def cleanup(project, data):
     messages = []
     status = 200
     for image, tag in get_image_delete_list(project, data):
@@ -161,6 +160,7 @@ def cleanup(data):
         messages.append(message)
 
     return JsonResponse(messages, status=status)
+
 
 if __name__ == "__main__":
     logger = logging.getLogger(__name__)

--- a/gitlab-registry-cleanup-hook.py
+++ b/gitlab-registry-cleanup-hook.py
@@ -133,15 +133,15 @@ def delete_image(image, tag):
     digest = client.get_digest(image, tag)
     if digest == None:
         logger.info("Image not present")
-        return {'message' : 'Image not found', 'image': image, 'tag': tag, 'code': 404}
+        return {'message': 'Image not found', 'image': image, 'tag': tag, 'code': 404}
 
     result = client.delete_image(image, tag)
     if result:
         logger.info("Deleted %s:%s" % (image, tag))
-        return {'message' : 'Image deleted', 'image': image, 'tag': tag, 'code': 200}
+        return {'message': 'Image deleted', 'image': image, 'tag': tag, 'code': 200}
 
     logger.info("Image not deleted")
-    return {'message' : 'Image not deleted', 'image': image, 'tag': tag, 'code': 202}
+    return {'message': 'Image not deleted', 'image': image, 'tag': tag, 'code': 202}
 
 
 def cleanup(project, data):
@@ -154,7 +154,7 @@ def cleanup(project, data):
                 status = message['code']
         except requests.exceptions.HTTPError as error:
             logger.fatal(error)
-            message = {'message' : 'Underlying HTTP error. Details not disclosed.', 'image': image, 'tag': tag, 'code': 500}
+            message = {'message': 'Underlying HTTP error. Details not disclosed.', 'image': image, 'tag': tag, 'code': 500}
             status = 500
 
         messages.append(message)

--- a/gitlab-registry-cleanup-hook.py
+++ b/gitlab-registry-cleanup-hook.py
@@ -110,9 +110,8 @@ def get_image_delete_list(project, data):
     image_template = config.get('IMAGE_NAME_TEMPLATE', '%(project_path)s/branches:%(branch)s')
     project_attribute = config.get('IMAGE_NAME_PROJECT_ATTRIBUTE')
     if project_attribute:
-        # https://python-gitlab.readthedocs.io/en/stable/gl_objects/projects.html#project-custom-attributes
         try:
-            # https://python-gitlab.readthedocs.io/en/stable/api/gitlab.v4.html#gitlab.v4.objects.ProjectCustomAttribute
+            # https://python-gitlab.readthedocs.io/en/stable/gl_objects/projects.html#project-custom-attributes
             attribute = project.customattributes.get(project_attribute)
             # https://python-gitlab.readthedocs.io/en/stable/api/gitlab.v4.html#gitlab.v4.objects.ProjectCustomAttribute
             image_template = attribute.value

--- a/set-project-attribute.sh
+++ b/set-project-attribute.sh
@@ -33,7 +33,7 @@ test -e .env && load_env .env
 project=$(echo "${1:-}" | sed -e 's;/;%2f;g')
 value="${2:-}"
 
-test -n "$project" || die "Usage: $0 project_id/project_path value"
+test -n "$project" || die "Usage: $0 project_id/project_path [value]"
 test -n "$GITLAB_TOKEN" || die "GITLAB_TOKEN missing"
 test -n "$GITLAB_API_URL" || die "GITLAB_API_URL missing"
 test -n "$IMAGE_NAME_PROJECT_ATTRIBUTE" || die "IMAGE_NAME_PROJECT_ATTRIBUTE missing"

--- a/set-project-attribute.sh
+++ b/set-project-attribute.sh
@@ -1,0 +1,49 @@
+#!/bin/sh
+#
+# This script is part of https://github.com/glensc/gitlab-registry-cleanup-hook
+# Author: Elan Ruusamäe <glen@pld-linux.org>
+#
+# Set project custom attribute:
+# https://docs.gitlab.com/ce/api/custom_attributes.html
+
+set -eu
+
+die() {
+	echo >&2 "$0: $*"
+	exit 1
+}
+
+# need to load it with grep, because it's not shell syntax compatible
+load_env() {
+	local file="$1" t name value
+	t=$(mktemp)
+
+	grep '^[^#]' $file > $t
+	while read line; do
+		name=${line%%=*}
+		value=${line#*=}
+		eval "$name='$value'"
+	done < $t
+	rm -f $t
+}
+
+# load .env if present
+test -e .env && load_env .env
+
+project=$(echo "${1:-}" | sed -e 's;/;%2f;g')
+value="${2:-}"
+
+test -n "$project" || die "Usage: $0 project_id/project_path value"
+test -n "$GITLAB_TOKEN" || die "GITLAB_TOKEN missing"
+test -n "$GITLAB_API_URL" || die "GITLAB_API_URL missing"
+test -n "$IMAGE_NAME_PROJECT_ATTRIBUTE" || die "IMAGE_NAME_PROJECT_ATTRIBUTE missing"
+
+# if value is empty, delete the attribute
+if [ -n "$value" ]; then
+	set -- --request PUT --data-urlencode "value=$value"
+else
+	set -- --request DELETE
+fi
+
+set -- "$@" --header "Private-Token: $GITLAB_TOKEN" "$GITLAB_API_URL/api/v4/projects/$project/custom_attributes/$IMAGE_NAME_PROJECT_ATTRIBUTE"
+exec curl "$@"


### PR DESCRIPTION
Adds configuration option to configure images to delete:

```sh
# template to use to construct image to cleanup
IMAGE_NAME_TEMPLATE=%(project_path)s/branches:%(branch)s
```

This can be also set per project:

This will configure to cleanup `branches:BRANCH_NAME-node-8` and `branch:BRANCH_NAME-node-10` images when MR is merged:
```bash
$ ./set-project-attribute.sh gitlab-org/gitlab-ce '%(project_path)s/branches:%(branch)s-node-8,%(project_path)s/branches:%(branch)s-node-10'
{"key":"custom_attribute","value":"%(project_path)s/branches:%(branch)s-node-8,%(project_path)s/branches:%(branch)s-node-10"}
```


Solves #2 
